### PR TITLE
Organizer files in the project

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -1,0 +1,8 @@
+package collection
+
+// Collection is a struct that stores a list of HQs
+type Collection struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Publisher string `json:"published"`
+}

--- a/collection/collection.repository.go
+++ b/collection/collection.repository.go
@@ -14,7 +14,7 @@ import (
 // collections without having to iterate over all the items in the
 // slice. The value is the collection itself.
 //
-// We use mutex because our webserice is multi-threaded and maps
+// We use mutex because our webservice is multi-threaded and maps
 // in Golang are not naturally thread-safe, which means we need to wrap
 // our map in a mutex to avoid two threads from writing and reading
 // the `map` at the same time.

--- a/collection/collection.repository.go
+++ b/collection/collection.repository.go
@@ -1,0 +1,120 @@
+package collection
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"sort"
+	"sync"
+)
+
+// collectionID is the key for the map, allowing us to access
+// collections without having to iterate over all the items in the
+// slice. The value is the collection itself.
+//
+// We use mutex because our webserice is multi-threaded and maps
+// in Golang are not naturally thread-safe, which means we need to wrap
+// our map in a mutex to avoid two threads from writing and reading
+// the `map` at the same time.
+var collectionsMap = struct {
+	sync.RWMutex
+	m map[int]Collection
+}{m: make(map[int]Collection)}
+
+func init() {
+	fmt.Println("loading collections...")
+	collectionMap, err := loadCollectionsMap()
+	collectionsMap.m = collectionMap
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("%d collections loaded...\n", len(collectionsMap.m))
+}
+
+func loadCollectionsMap() (map[int]Collection, error) {
+	fileName := "data/collections.json"
+	_, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("file [%s] does not exist", fileName)
+	}
+
+	file, _ := ioutil.ReadFile(fileName)
+	collectionList := make([]Collection, 0)
+	err = json.Unmarshal([]byte(file), &collectionList)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	collectionMap := make(map[int]Collection)
+	for i := 0; i < len(collectionList); i++ {
+		collectionMap[collectionList[i].ID] = collectionList[i]
+	}
+
+	return collectionMap, nil
+}
+
+func getCollection(collectionID int) *Collection {
+	collectionsMap.RLock()
+	defer collectionsMap.RUnlock()
+
+	if collection, ok := collectionsMap.m[collectionID]; ok {
+		return &collection
+	}
+
+	return nil
+}
+
+func removeCollection(collectionID int) {
+	collectionsMap.Lock()
+	defer collectionsMap.Unlock()
+	delete(collectionsMap.m, collectionID)
+}
+
+func getCollectionsList() []Collection {
+	collectionsMap.RLock()
+	collections := make([]Collection, 0, len(collectionsMap.m))
+	for _, value := range collectionsMap.m {
+		collections = append(collections, value)
+	}
+	collectionsMap.RUnlock()
+	return collections
+}
+
+func getCollectionsIDs() []int {
+	collectionsMap.RLock()
+	collectionsIDs := []int{}
+	for key := range collectionsMap.m {
+		collectionsIDs = append(collectionsIDs, key)
+	}
+	collectionsMap.RUnlock()
+	sort.Ints(collectionsIDs)
+	return collectionsIDs
+}
+
+func getNextCollectionID() int {
+	collectionIDs := getCollectionsIDs()
+	return collectionIDs[len(collectionIDs)-1] + 1
+}
+
+func addOrUpdateCollection(collection Collection) (int, error) {
+	// if the collection id is set, update, otherwise add
+	addOrUpdateID := -1
+	if collection.ID > 0 {
+		oldCollection := getCollection(collection.ID)
+		// if it exists, replace it, otherwise return error
+		if oldCollection == nil {
+			return 0, fmt.Errorf("collection id [%d] doesn't exist", collection.ID)
+		}
+		addOrUpdateID = collection.ID
+	} else {
+		addOrUpdateID = getNextCollectionID()
+		collection.ID = addOrUpdateID
+	}
+	collectionsMap.Lock()
+	collectionsMap.m[addOrUpdateID] = collection
+	collectionsMap.Unlock()
+	return addOrUpdateID, nil
+}

--- a/collection/collection.server.go
+++ b/collection/collection.server.go
@@ -1,0 +1,115 @@
+package collection
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"hq-collections.com/cors"
+)
+
+const collectionsPath = "collections"
+
+func handleCollections(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		collectionList := getCollectionsList()
+		j, err := json.Marshal(collectionList)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = w.Write(j)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case http.MethodPost:
+		var collection Collection
+		err := json.NewDecoder(r.Body).Decode(&collection)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err = addOrUpdateCollection(collection)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	case http.MethodOptions:
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func handleCollection(w http.ResponseWriter, r *http.Request) {
+	urlPathSegments := strings.Split(r.URL.Path, fmt.Sprintf("%s/", collectionsPath))
+	if len(urlPathSegments[1:]) > 1 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	collectionID, err := strconv.Atoi(urlPathSegments[len(urlPathSegments)-1])
+	if err != nil {
+		log.Print(err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		collection := getCollection(collectionID)
+		if collection == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		j, err := json.Marshal(collection)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err = w.Write(j)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	case http.MethodPut:
+		var collection Collection
+		err := json.NewDecoder(r.Body).Decode(&collection)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if collection.ID != collectionID {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err = addOrUpdateCollection(collection)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	case http.MethodDelete:
+		removeCollection(collectionID)
+
+	case http.MethodOptions:
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// SetupRoutes is a temporary routing method. It must be improved
+// with Mux.
+func SetupRoutes(apiBasePath string) {
+	collectionsHandler := http.HandlerFunc(handleCollections)
+	collectionHandler := http.HandlerFunc(handleCollection)
+	http.Handle(fmt.Sprintf("%s/%s", apiBasePath, collectionsPath), cors.Middleware(collectionsHandler))
+	http.Handle(fmt.Sprintf("%s/%s/", apiBasePath, collectionsPath), cors.Middleware(collectionHandler))
+}

--- a/cors/middleware.go
+++ b/cors/middleware.go
@@ -1,0 +1,13 @@
+package cors
+
+import "net/http"
+
+func Middleware(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Access-Control-Allow-Origin", "*")
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		w.Header().Add("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/data/collections.json
+++ b/data/collections.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1,
+    "name": "Turma da Mônica",
+    "published": "X"
+  },
+  {
+    "id": 2,
+    "name": "Asterix",
+    "published": "Y"
+  }
+]

--- a/data/volumes.json
+++ b/data/volumes.json
@@ -1,0 +1,31 @@
+
+[
+  {
+    "id": 1,
+    "collection_id": 1,
+    "name": "Almanacão",
+    "edition": "1",
+    "pages": 39
+  },
+  {
+    "id": 2,
+    "collection_id": 1,
+    "name": "Especial de natal",
+    "edition": "Especial",
+    "pages": 20
+  },
+  {
+    "id": 3,
+    "collection_id": 2,
+    "name": "Asterix em São Paulo",
+    "edition": "2",
+    "pages": 120
+  },
+  {
+    "id": 4,
+    "collection_id": 2,
+    "name": "Asterix en français",
+    "edition": "Francesa",
+    "pages": 2
+  }
+]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hq-collections.com
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -1,95 +1,22 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+
+	"hq-collections.com/collection"
+	"hq-collections.com/volume"
 )
 
-// Collection is a struct that does something
-type Collection struct {
-	ID        int    `json:"id"`
-	Name      string `json:"name"`
-	Publisher string `json:"published"`
-}
-
-type Volume struct {
-	ID           int    `json:"id"`
-	CollectionID int    `json:"collection_id"`
-	Name         string `json:"name"`
-	Edition      string `json:"edition"`
-	Pages        int    `json:"pages"`
-}
-
-var collectionList = []Collection{
-	{1, "Turma da Mônica", "X"},
-	{2, "Asterix", "Y"},
-}
-
-var volumesList = []Volume{
-	{1, 1, "Almanacão", "1", 39},
-	{2, 1, "Especial de natal", "especial", 20},
-	{3, 2, "Asterix em São Paulo", "3", 120},
-	{4, 2, "Asterix en français", "francesa", 2},
-}
-
-func collectionHandler(w http.ResponseWriter, r *http.Request) {
-	jsonList, err := json.Marshal(collectionList)
-	if err != nil {
-		panic(err)
-	}
-
-	w.Write([]byte(jsonList))
-}
-
-// FindVolumes is a function that...
-func (collection Collection) FindVolumes() []Volume {
-	result := []Volume{}
-	for _, volume := range volumesList {
-		if volume.CollectionID == collection.ID {
-			result = append(result, volume)
-		}
-	}
-	return result
-}
-
-func volumesHandler(w http.ResponseWriter, r *http.Request) {
-	// fmt.Println("asdasd")
-	// urlPathSegments := strings.Split(r.URL.Path, "/volumes")
-	// fmt.Println(string(urlPathSegments[0][1:]))
-	// collectionID, err := strconv.Atoi(string(urlPathSegments[0][1:]))
-	// if err != nil {
-	// 	w.WriteHeader(http.StatusNotFound)
-	// 	return
-	// }
-
-	collectionID := 2
-
-	emptyCollection := Collection{}
-	currentCollection := emptyCollection
-	for _, item := range collectionList {
-		if item.ID == collectionID {
-			currentCollection = item
-		}
-	}
-
-	if currentCollection == emptyCollection {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	jsonList, err := json.Marshal(currentCollection.FindVolumes())
-	if err != nil {
-		panic(err)
-	}
-
-	w.Write([]byte(jsonList))
-}
+const basePath = "/api"
 
 func main() {
-	// http.HandleFunc(`/{id:[0-9]+}/volumes`, volumesHandler)
-	http.HandleFunc(`/volumes`, volumesHandler)
-	http.HandleFunc("/collections", collectionHandler)
-	fmt.Println("Waiting for requests...")
-	http.ListenAndServe(":5000", nil)
+	collection.SetupRoutes(basePath)
+	volume.SetupRoutes(basePath)
+	fmt.Println("Webserver is up and running, waiting for connections...")
+	err := http.ListenAndServe(":5000", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -1,0 +1,10 @@
+package volume
+
+// Volume is a struct that represents one HQ
+type Volume struct {
+	ID           int    `json:"id"`
+	CollectionID int    `json:"collection_id"`
+	Name         string `json:"name"`
+	Edition      string `json:"edition"`
+	Pages        int    `json:"pages"`
+}

--- a/volume/volume.repository.go
+++ b/volume/volume.repository.go
@@ -14,7 +14,7 @@ import (
 // volumes without having to iterate over all the items in the
 // slice. The value is the volume itself.
 //
-// We use mutex because our webserice is multi-threaded and maps
+// We use mutex because our webservice is multi-threaded and maps
 // in Golang are not naturally thread-safe, which means we need to wrap
 // our map in a mutex to avoid two threads from writing and reading
 // the `map` at the same time.

--- a/volume/volume.repository.go
+++ b/volume/volume.repository.go
@@ -1,0 +1,120 @@
+package volume
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"sort"
+	"sync"
+)
+
+// volumeID is the key for the map, allowing us to access
+// volumes without having to iterate over all the items in the
+// slice. The value is the volume itself.
+//
+// We use mutex because our webserice is multi-threaded and maps
+// in Golang are not naturally thread-safe, which means we need to wrap
+// our map in a mutex to avoid two threads from writing and reading
+// the `map` at the same time.
+var volumesMap = struct {
+	sync.RWMutex
+	m map[int]Volume
+}{m: make(map[int]Volume)}
+
+func init() {
+	fmt.Println("loading volumes...")
+	volumeMap, err := loadVolumesMap()
+	volumesMap.m = volumeMap
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("%d volumes loaded...\n", len(volumesMap.m))
+}
+
+func loadVolumesMap() (map[int]Volume, error) {
+	fileName := "data/volumes.json"
+	_, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("file [%s] does not exist", fileName)
+	}
+
+	file, _ := ioutil.ReadFile(fileName)
+	volumeList := make([]Volume, 0)
+	err = json.Unmarshal([]byte(file), &volumeList)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	volumesMap := make(map[int]Volume)
+	for i := 0; i < len(volumeList); i++ {
+		volumesMap[volumeList[i].ID] = volumeList[i]
+	}
+
+	return volumesMap, nil
+}
+
+func getVolume(volumeID int) *Volume {
+	volumesMap.RLock()
+	defer volumesMap.RUnlock()
+
+	if volume, ok := volumesMap.m[volumeID]; ok {
+		return &volume
+	}
+
+	return nil
+}
+
+func removeVolume(volumeID int) {
+	volumesMap.Lock()
+	defer volumesMap.Unlock()
+	delete(volumesMap.m, volumeID)
+}
+
+func getVolumesList() []Volume {
+	volumesMap.RLock()
+	volumes := make([]Volume, 0, len(volumesMap.m))
+	for _, value := range volumesMap.m {
+		volumes = append(volumes, value)
+	}
+	volumesMap.RUnlock()
+	return volumes
+}
+
+func getVolumesIDs() []int {
+	volumesMap.RLock()
+	volumesIDs := []int{}
+	for key := range volumesMap.m {
+		volumesIDs = append(volumesIDs, key)
+	}
+	volumesMap.RUnlock()
+	sort.Ints(volumesIDs)
+	return volumesIDs
+}
+
+func getNextVolumeID() int {
+	volumesIDs := getVolumesIDs()
+	return volumesIDs[len(volumesIDs)-1] + 1
+}
+
+func addOrUpdateVolume(volume Volume) (int, error) {
+	// if the volume id is set, update, otherwise add
+	addOrUpdateID := -1
+	if volume.ID > 0 {
+		oldVolume := getVolume(volume.ID)
+		// if it exists, replace it, otherwise return error
+		if oldVolume == nil {
+			return 0, fmt.Errorf("volume id [%d] doesn't exist", volume.ID)
+		}
+		addOrUpdateID = volume.ID
+	} else {
+		addOrUpdateID = getNextVolumeID()
+		volume.ID = addOrUpdateID
+	}
+	volumesMap.Lock()
+	volumesMap.m[addOrUpdateID] = volume
+	volumesMap.Unlock()
+	return addOrUpdateID, nil
+}

--- a/volume/volume.server.go
+++ b/volume/volume.server.go
@@ -1,0 +1,115 @@
+package volume
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"hq-collections.com/cors"
+)
+
+const volumesPath = "volumes"
+
+func handleVolumes(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		volumeList := getVolumesList()
+		j, err := json.Marshal(volumeList)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = w.Write(j)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case http.MethodPost:
+		var volume Volume
+		err := json.NewDecoder(r.Body).Decode(&volume)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err = addOrUpdateVolume(volume)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	case http.MethodOptions:
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func handleVolume(w http.ResponseWriter, r *http.Request) {
+	urlPathSegments := strings.Split(r.URL.Path, fmt.Sprintf("%s/", volumesPath))
+	if len(urlPathSegments[1:]) > 1 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	volumeID, err := strconv.Atoi(urlPathSegments[len(urlPathSegments)-1])
+	if err != nil {
+		log.Print(err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		volume := getVolume(volumeID)
+		if volume == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		j, err := json.Marshal(volume)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err = w.Write(j)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	case http.MethodPut:
+		var volume Volume
+		err := json.NewDecoder(r.Body).Decode(&volume)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if volume.ID != volumeID {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err = addOrUpdateVolume(volume)
+		if err != nil {
+			log.Print(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	case http.MethodDelete:
+		removeVolume(volumeID)
+
+	case http.MethodOptions:
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// SetupRoutes is a temporary routing method. It must be improved
+// with Mux.
+func SetupRoutes(apiBasePath string) {
+	volumesHandler := http.HandlerFunc(handleVolumes)
+	volumeHandler := http.HandlerFunc(handleVolume)
+	http.Handle(fmt.Sprintf("%s/%s", apiBasePath, volumesPath), cors.Middleware(volumesHandler))
+	http.Handle(fmt.Sprintf("%s/%s/", apiBasePath, volumesPath), cors.Middleware(volumeHandler))
+}


### PR DESCRIPTION
The organization suggestion here is to isolate each domain of our project in its own folder. Taking a `collection` as an example, it would have:

```
/collection
    collection.go // this is where we store the collection model 
    collection.repository.go // this is the layer that access the `database`. When we use GORM, I guess we are going to replace this file
    collection.server.go // this is where we manage http and routes
```

I had to remove that findVolume method we attached to the Collection struct. It was very nice, but I could not figure out how to use it in this structure, I need to study more. Maybe it is simply not the Go way.