### PR TITLE
Centralize routes in one place

### DIFF
--- a/collection/collection.server.go
+++ b/collection/collection.server.go
@@ -7,13 +7,9 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
-	"hq-collections.com/cors"
 )
 
-const collectionsPath = "collections"
-
-func handleCollections(w http.ResponseWriter, r *http.Request) {
+func HandleCollections(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		collectionList := getCollectionsList()
@@ -47,8 +43,10 @@ func handleCollections(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleCollection(w http.ResponseWriter, r *http.Request) {
-	urlPathSegments := strings.Split(r.URL.Path, fmt.Sprintf("%s/", collectionsPath))
+func HandleCollection(w http.ResponseWriter, r *http.Request) {
+	// TODO: the `collections` here is the collectionsPath set on routes.go, it is
+	// duplicated. This will be fixed when we start using mux.
+	urlPathSegments := strings.Split(r.URL.Path, fmt.Sprintf("%s/", "collections"))
 	if len(urlPathSegments[1:]) > 1 {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -103,13 +101,4 @@ func handleCollection(w http.ResponseWriter, r *http.Request) {
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
-}
-
-// SetupRoutes is a temporary routing method. It must be improved
-// with Mux.
-func SetupRoutes(apiBasePath string) {
-	collectionsHandler := http.HandlerFunc(handleCollections)
-	collectionHandler := http.HandlerFunc(handleCollection)
-	http.Handle(fmt.Sprintf("%s/%s", apiBasePath, collectionsPath), cors.Middleware(collectionsHandler))
-	http.Handle(fmt.Sprintf("%s/%s/", apiBasePath, collectionsPath), cors.Middleware(collectionHandler))
 }

--- a/main.go
+++ b/main.go
@@ -4,16 +4,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"hq-collections.com/collection"
-	"hq-collections.com/volume"
 )
 
 const basePath = "/api"
 
 func main() {
-	collection.SetupRoutes(basePath)
-	volume.SetupRoutes(basePath)
+	SetupRoutes(basePath)
 	fmt.Println("Webserver is up and running, waiting for connections...")
 	err := http.ListenAndServe(":5000", nil)
 	if err != nil {

--- a/routes.go
+++ b/routes.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"hq-collections.com/collection"
+	"hq-collections.com/cors"
+	"hq-collections.com/volume"
+)
+
+const collectionsPath = "collections"
+const volumesPath = "volumes"
+
+// SetupRoutes is a temporary routing method. It must be improved
+// with Mux.
+func SetupRoutes(apiBasePath string) {
+	collectionsHandler := http.HandlerFunc(collection.HandleCollections)
+	collectionHandler := http.HandlerFunc(collection.HandleCollection)
+	http.Handle(fmt.Sprintf("%s/%s", apiBasePath, collectionsPath), cors.Middleware(collectionsHandler))
+	http.Handle(fmt.Sprintf("%s/%s/", apiBasePath, collectionsPath), cors.Middleware(collectionHandler))
+
+	volumesHandler := http.HandlerFunc(volume.HandleVolumes)
+	volumeHandler := http.HandlerFunc(volume.HandleVolume)
+	http.Handle(fmt.Sprintf("%s/%s", apiBasePath, volumesPath), cors.Middleware(volumesHandler))
+	http.Handle(fmt.Sprintf("%s/%s/", apiBasePath, volumesPath), cors.Middleware(volumeHandler))
+
+}

--- a/volume/volume.server.go
+++ b/volume/volume.server.go
@@ -7,13 +7,9 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
-	"hq-collections.com/cors"
 )
 
-const volumesPath = "volumes"
-
-func handleVolumes(w http.ResponseWriter, r *http.Request) {
+func HandleVolumes(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		volumeList := getVolumesList()
@@ -47,8 +43,10 @@ func handleVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleVolume(w http.ResponseWriter, r *http.Request) {
-	urlPathSegments := strings.Split(r.URL.Path, fmt.Sprintf("%s/", volumesPath))
+func HandleVolume(w http.ResponseWriter, r *http.Request) {
+	// TODO: the `volumes` here is the volumesPath set on routes.go, it is
+	// duplicated. This will be fixed when we start using mux.
+	urlPathSegments := strings.Split(r.URL.Path, fmt.Sprintf("%s/", "volumes"))
 	if len(urlPathSegments[1:]) > 1 {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -103,13 +101,4 @@ func handleVolume(w http.ResponseWriter, r *http.Request) {
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
-}
-
-// SetupRoutes is a temporary routing method. It must be improved
-// with Mux.
-func SetupRoutes(apiBasePath string) {
-	volumesHandler := http.HandlerFunc(handleVolumes)
-	volumeHandler := http.HandlerFunc(handleVolume)
-	http.Handle(fmt.Sprintf("%s/%s", apiBasePath, volumesPath), cors.Middleware(volumesHandler))
-	http.Handle(fmt.Sprintf("%s/%s/", apiBasePath, volumesPath), cors.Middleware(volumeHandler))
 }


### PR DESCRIPTION
Following [@felipsimoes' suggestion](https://github.com/felipsimoes/hq-api/pull/1), I moved all routes to one file, it will be easier to move to Mux this way.

The `handle` functions needed to have capital letter to be exporter, and there are two TODO's in the code showing a place where I had to duplicate code. Fortunately, they will be removed when we use Mux.